### PR TITLE
update: use slash commands instead

### DIFF
--- a/docs/automod.md
+++ b/docs/automod.md
@@ -7,10 +7,10 @@ This article will walk you through setting up, configuring, and using Bulbbot au
 
 ## Auto Moderation Logging
 ---
-Automod has its own special log type which will log all censored messages in a channel you select. You can configure this channel using `!configure logging automod <channel>`
+Automod has its own special log type which will log all censored messages in a channel you select. You can configure this channel using `/configure logging type: Automod logs <channel>`
 
 :::caution note
-Automod will **not** log or cache messages until you enable it with `!configure automod enable`
+Automod will **not** log or cache messages until you enable it with `/configure automod enable`
 :::
 
 Once enabled, AutoMod will delete, log and action on any messages violating our checks. These messages will log in your desired channel.
@@ -23,7 +23,7 @@ Bulbbot AutoMod currently offers `7` censoring options `messages`, `mentions`, `
 
 These censoring options are divided into two categories. `messages` and `mentions` can only use **limits** while `websites`, `words` and `invites` can only use **blacklists and whitelists**. 
 
-To view all of your automod configuration use the `!configure automod settings` command.
+To view all of your automod configuration use the `/configure automod settings` command.
 
 ### Limits
 ---
@@ -32,15 +32,14 @@ Messages containing user mentions are cached in the Automod cache for `15 second
 :::
 
 Once you set up mention or message limits Bulbbot will cache all messages and messages containing mentions respectively. You can
-set up mention or message limits using the `!configure automod limit mentions <limit>` or `!configure automod limit messages <limit>` commands. Once a user has
-violated these checks the configured action will trigger and Bulbbot will log the check violation in your automod channel.
+set up mention or message limits using the `/configure automod limit category: mentions <limit>` or `/configure automod limit category: messages <limit>` commands. Once a user has violated these checks the configured action will trigger and Bulbbot will log the check violation in your automod channel.
 
 
 ### Words/Words_token
 ---
 Bulbbot censoring allows you to set up two different checks for swear words `words` and `words_token`.
 `words` only checks for standalone words while `words_token` checks for the word token anywhere in the message.
-You can configure them using `!configure automod words add <word>` or `!configure automod words_token add <word>`.
+You can configure them using `/configure automod add part: words <items>` or `/configure automod add part: words_token <items>`.
 
 
 
@@ -51,7 +50,7 @@ Both `words` and `words_token` use the **same** configured punishment from `word
 ### Invites
 ---
 The **invites** check will check all messages for Discord invites and will action on and delete messages that contain any invites that are not whitelisted.
-You can whitelist invites using the `!configure automod add invites <invite>` command.
+You can whitelist invites using the `/configure automod add part: invites <items>` command.
 
 :::note tip
 We recommend using the full invite link (i.e https://discord.gg/invite/WgEtVqyNFZ) to make sure everything works correctly
@@ -59,7 +58,7 @@ We recommend using the full invite link (i.e https://discord.gg/invite/WgEtVqyNF
 ### Websites
 ---
 The **website** check will check all messages for any websites and will action on and delete messages that violate this check unless the message contains a whitelisted website.
-You can whitelist websites using the `!configure automod add website <website>` command.
+You can whitelist websites using the `/configure automod add part: website <items>` command.
 
 ## Auto Moderation Punishments
 ---
@@ -69,6 +68,6 @@ Bulbbot currently allows you to configure **4** different automod actions.
 * `KICK` - Kicks the user, deletes and logs the censored content in your logging channel
 * `BAN` - Cleanbans the user and logs the censored content in your logging channel
 
-You can configure them using the `!configure automod punishment <check> <action>` command. Let's set the auto response for `mentions` to ban as an example:
+You can configure them using the `/configure automod punishment <category> <punishment>` command. Let's set the auto response for `mentions` to ban as an example:
 
 

--- a/docs/clearance.md
+++ b/docs/clearance.md
@@ -10,7 +10,7 @@ Instead of the traditional Trusted, Moderator and Administrator roles most other
 Before you begin configuring and changing this clearance values please note that the `@everyone` role has a clearance level of `0` by default. This allows anyone with the `@everyone` role or any other role that does not have any special permissions to use commands that by default have a clearance level of `0`. Anyone with a role that has the `ADMINISTRATOR` permission grated will **automatically** be assigned a clearance value of `75`. The Server Owner will be granted a clearance level of `100` by default and is the only one that can use all Bulbbot commands regardless of the command or role overrides.
 
 :::caution note
-Some commands are also affected by Discord's default permissions as well. This means that if a role has a clearance level of less than `50` but has the `BAN_MEMBERS` permission granted, users with that role will be able to access any commands that require said permission, i.e. `!ban`.
+Some commands are also affected by Discord's default permissions as well. This means that if a role has a clearance level of less than `50` but has the `BAN_MEMBERS` permission granted, users with that role will be able to access any commands that require said permission, i.e. `/ban`.
 :::
 
 You can read through our [command list](command-list) for more information about what clearance level each command has.
@@ -21,16 +21,16 @@ Bulbbot assigns each command a certain clearance level by default. These default
 
 ### 2. Editing role and command permissions
 
-If you are sure you need to edit the role or command clearance levels you can do so by simply using the `!configure override` command. You can add a custom clearance level to roles using `!configure override create role <name> <clearance>` or `!configure override create command <name> <clearance>` for commands. These overrides can also be edited using `!configure override edit <part> <name> <clearance>` or deleted using `!configure override delete <part> <name> <name>`.
+If you are sure you need to edit the role or command clearance levels you can do so by simply using the `/configure override` command. You can add a custom clearance level to roles using `/configure override create role <name> <clearance>` or `/configure override create command <name> <clearance>` for commands. These overrides can also be edited using `/configure override edit <type> <name> <clearance>` or deleted using `/configure override delete <type> <name>`.
 
 ![Clearance](./assets/Configuration/Clearance_Overrides.gif)
 
 :::tip
-If you need to disable or enable commands completely you can do so using `!configure override enable <command>` or `!configure override disable <command>`. Disabled commands will not trigger in your server until you re-enable them.
+If you need to disable or enable commands completely you can do so using `/configure override enable <name>` or `/configure override disable <name>`. Disabled commands will not trigger in your server until you re-enable them.
 :::
 
 ### 3. Checking command overrides
 
-If you ever forget about a command or role override you created or want to check on all the overrides you've created you can do so using the `!configure override list` command.
+If you ever forget about a command or role override you created or want to check on all the overrides you've created you can do so using the `/configure override list` command.
 
 ![Override_list](./assets/Configuration/Override_List.gif)

--- a/docs/command-list.md
+++ b/docs/command-list.md
@@ -4,8 +4,7 @@ title: Command List
 ---
 
 :::info note
-- Bulbbot's default prefix is `!` unless you've changed it yourself using the `!configure` command. You can check Bulbbot's prefix in your server by mentioning `@Bulbbot#1439`
-- Bulbbot also offers commands via Discords slash commands `/`, for more info see [this article about it](slash-commands)
+- Bulbbot offers only commands via Discords slash commands `/`, for more info see [this article about it](slash-commands)
 - Arguments such as `User` or `Member` can be parsed **multiple ways**, either as a mention `@KlukCZ#6589` or User ID `439396770695479297`
 - The `Time` argument must be parsed as a standard moment time (`1h`, `30m` etc.)
 :::
@@ -15,12 +14,12 @@ title: Command List
 |    Command        |         Aliases        | Default Clearance |                        Description                        |      Usage      |    Arguments     |
 | :-------------:   | :--------------------: | :---------------: | :-------------------------------------------------------: | :-------------: | :--------------: |
 | about | `bot` | 0 | Returns some useful information about the bot | about |  |
-| commands |  | 0 | Return a list of all available commands to Bulbbot | commands |  |
-| github | `code`, `sourcecode` | 0 | Return a link to the github repository | github |  |
-| help |  | 0 | Gets useful information about a given command | help &lt;command&gt; [subcommand...] | `command:string` |
+| commands |  | 0 | Returns a list of all available commands to Bulbbot | commands |  |
+| github | `code`, `sourcecode` | 0 | Returns a link to the github repository | github |  |
+| help |  | 0 | Gets useful information about a given command | help &lt;command&gt; [subcommand...] | `command:String` |
 | invite | `support` | 0 | Returns the invite link for the bot and the support server | invite |  |
 | license |  | 0 | Returns the license file for the Github repo for the bot | license |  |
-| ping |  | 0 | Return the Websocket and API latency | ping |  |
+| ping |  | 0 | Returns the Websocket and API latency | ping |  |
 | privacypolicy |  | 0 | Returns the privacy policy for the bot | privacypolicy |  |
 | uptime |  | 0 | Shows the bot's uptime. | uptime |  |
 
@@ -29,40 +28,40 @@ title: Command List
 ---
 |    Command        |         Aliases        | Default Clearance |                        Description                        |      Usage      |    Arguments     |
 | :-------------:   | :--------------------: | :---------------: | :-------------------------------------------------------: | :-------------: | :--------------: |
-| banpool create |  | 100 | Create a new banpool. | banpool create &lt;pool name&gt; | `pool name:string` |
-| banpool delete | `del` | 100 | Delete a banpool. | banpool delete &lt;pool name&gt; | `pool name:string` |
-| banpool invite | `inv` | 100 | Generates an invite code for the specified ban pool. | banpool invite &lt;pool name&gt; | `pool name:string` |
-| banpool join |  | 100 | Join a banpool. | banpool join &lt;code&gt; | `code:string` |
-| banpool leave |  | 100 | Manage banpools. | banpool leave &lt;pool name&gt; | `pool name:string` |
-| banpool remove | `kick` | 100 | Removes a guild from a banpool. | banpool remove &lt;guildId&gt; &lt;poolname&gt; | `guildId:snowflake`, `pool name:string` |
-| banpool info |  | 100 | Get information about a banpool. | banpool info &lt;pool name&gt; | `pool name:string` |
+| banpool create |  | 100 | Create a new banpool. | banpool create &lt;pool name&gt; | `pool name:String` |
+| banpool delete | `del` | 100 | Delete a banpool. | banpool delete &lt;pool name&gt; | `pool name:String` |
+| banpool invite | `inv` | 100 | Generates an invite code for the specified ban pool. | banpool invite &lt;pool name&gt; | `pool name:String` |
+| banpool join |  | 100 | Join a banpool. | banpool join &lt;code&gt; | `code:String` |
+| banpool leave |  | 100 | Manage banpools. | banpool leave &lt;pool name&gt; | `pool name:String` |
+| banpool remove | `kick` | 100 | Removes a guild from a banpool. | banpool remove &lt;guildId&gt; &lt;poolname&gt; | `guildId:Snowflake`, `pool name:String` |
+| banpool info |  | 100 | Get information about a banpool. | banpool info &lt;pool name&gt; | `pool name:String` |
 | banpool list |  | 100 | Manage banpools. | banpool list |  |
-| configure timezone | `zone`, `tz` | 75 | Sets the timezone for the server. | configure timezone &lt;zone&gt; | `timezone:string` |
-| configure prefix |  | 75 | Sets the prefix for the bot. | configure prefix &lt;prefix&gt; | `prefix:string` |
-| configure logging | `log`, `logs` | 75 | Configure the logging of a part of the bot. | configure logging &lt;part&gt; &lt;channel&gt; | `part:string`, `channel:Channel` |
+| configure timezone | `zone`, `tz` | 75 | Sets the timezone for the server. | configure timezone &lt;zone&gt; | `timezone:String` |
+| configure prefix |  | 75 | Sets the prefix for the bot. | configure prefix &lt;prefix&gt; | `prefix:String` |
+| configure logging | `log`, `logs` | 75 | Configure the logging of a part of the bot. | configure logging &lt;part&gt; &lt;channel&gt; | `part:String`, `channel:ChannelText` |
 | configure auto_role | `autorole` | 75 | Sets the role that will be given to users when they join the server. | configure auto_role &lt;role&gt; | `role:Role` |
-| configure override create |  | 75 |  Creates a new override for the specified part.  | configure override create &lt;part&gt; &lt;name&gt; &lt;clearance&gt; | `part:string`, `name:string`, `clearance:number` |
-| configure override disable |  | 75 |  Disables a command  | configure override disable &lt;command&gt; | `command:string` |
-| configure override edit |  | 75 |  Updates a clearance level.  | configure override edit &lt;part&gt; &lt;name&gt; &lt;clearance&gt; | `part:string`, `name:string`, `clearance:number` |
-| configure override enable |  | 75 |  Enables a command  | configure override enable &lt;command&gt; | `command:string` |
-| configure override list |  | 75 |  Lists all overrides for the current server.  | configure override list | `command:string` |
-| configure override delete | `remove`, `rm` | 75 |  Removes an override.  | configure override delete &lt;part&gt; &lt;name&gt; | `part:string`, `name:string` |
-| configure override | `overide` | 75 | Configure the override system. | configure override &lt;action&gt; | `action:string` |
+| configure override create |  | 75 |  Creates a new override for the specified part.  | configure override create &lt;part&gt; &lt;name&gt; &lt;clearance&gt; | `part:String`, `name:String`, `clearance:Number` |
+| configure override disable |  | 75 |  Disables a command  | configure override disable &lt;command&gt; | `command:String` |
+| configure override edit |  | 75 |  Updates a clearance level.  | configure override edit &lt;part&gt; &lt;name&gt; &lt;clearance&gt; | `part:String`, `name:String`, `clearance:Number` |
+| configure override enable |  | 75 |  Enables a command  | configure override enable &lt;command&gt; | `command:String` |
+| configure override list |  | 75 |  Lists all overrides for the current server.  | configure override list | `command:String` |
+| configure override delete | `remove`, `rm` | 75 |  Removes an override.  | configure override delete &lt;part&gt; &lt;name&gt; | `part:String`, `name:String` |
+| configure override | `overide` | 75 | Configure the override system. | configure override &lt;action&gt; | `action:String` |
 | configure automod enable |  | 75 |  Enables automod in this server.  | configure automod enable |  |
 | configure automod settings |  | 75 |  List of settings for the the automod system  | configure automod settings |  |
-| configure automod add |  | 75 |  Adds items to the specified part of the automod list.  | configure automod add &lt;part&gt; &lt;item&gt; [items...] | `part:string`, `item:string` |
+| configure automod add |  | 75 |  Adds items to the specified part of the automod list.  | configure automod add &lt;part&gt; &lt;item&gt; [items...] | `part:String`, `item:String` |
 | configure automod disable |  | 75 |  Disables automod for a part of the message.  | configure automod disable [part] |  |
-| configure automod remove | `rm` | 75 |  Removes items from the specified part of the automod list.  | configure automod remove &lt;part&gt; &lt;item&gt; [items...] | `part:string`, `item:string` |
-| configure automod punishment | `punish` | 75 |  Sets the punishment for a part of the automod system.  | configure automod punishment &lt;part&gt; &lt;punishment&gt; | `part:string`, `punishment:string` |
-| configure automod limit |  | 75 |  Sets the limit and timeout for a part of the automod system.  | configure automod limit &lt;part&gt; &lt;limit&gt; &lt;timeout&gt; | `part:string`, `limit:number`, `timeout:number` |
-| configure automod | `am` | 75 | Configure the automod in your server | configure automod &lt;action&gt; | `action:string` |
-| configure actions_on_info |  | 75 | Sets whether or not to the info command should show moderation actions | configure actions_on_info &lt;true|false&gt; | `enabled:boolean` |
-| configure language |  | 75 | Sets the language for the bot. | configure language &lt;language&gt; | `language:string` |
-| configure roles_on_leave | `rolesonleave` | 75 | Enable or disable the if roles should be logged on the leave message | configure roles_on_leave &lt;true|false&gt; | `enabled:boolean` |
-| configure quick_reasons add |  | 75 |  Adds a reason to the quick reasons list.  | configure quick_reasons add &lt;reason&gt; | `reason:string` |
-| configure quick_reasons remove | `delete`, `del` | 75 |  Removes a quick reason from the list.  | configure quick_reasons remove &lt;reason&gt; | `reason:string` |
-| configure quick_reasons | `quickreasons` | 75 | Configure quick reasons. | configure quick_reasons | `action:string` |
-| messageclear |  | 100 | clears X amount of messages from the database in the server | messageclear &lt;days&gt; | `days:number` |
+| configure automod remove | `rm` | 75 |  Removes items from the specified part of the automod list.  | configure automod remove &lt;part&gt; &lt;item&gt; [items...] | `part:String`, `item:String` |
+| configure automod punishment | `punish` | 75 |  Sets the punishment for a part of the automod system.  | configure automod punishment &lt;part&gt; &lt;punishment&gt; | `part:String`, `punishment:String` |
+| configure automod limit |  | 75 |  Sets the limit and timeout for a part of the automod system.  | configure automod limit &lt;part&gt; &lt;limit&gt; &lt;timeout&gt; | `part:String`, `limit:Number`, `timeout:Number` |
+| configure automod | `am` | 75 | Configure the automod in your server | configure automod &lt;action&gt; | `action:String` |
+| configure actions_on_info |  | 75 | Sets whether or not to the info command should show moderation actions | configure actions_on_info &lt;true|false&gt; | `enabled:Boolean` |
+| configure language |  | 75 | Sets the language for the bot. | configure language &lt;language&gt; | `language:String` |
+| configure roles_on_leave | `rolesonleave` | 75 | Enable or disable the if roles should be logged on the leave message | configure roles_on_leave &lt;true|false&gt; | `enabled:Boolean` |
+| configure quick_reasons add |  | 75 |  Adds a reason to the quick reasons list.  | configure quick_reasons add &lt;reason&gt; | `reason:String` |
+| configure quick_reasons remove | `delete`, `del` | 75 |  Removes a quick reason from the list.  | configure quick_reasons remove &lt;reason&gt; | `reason:String` |
+| configure quick_reasons | `quickreasons` | 75 | Configure quick reasons. | configure quick_reasons | `action:String` |
+| messageclear |  | 100 | clears X amount of messages from the database in the server | messageclear &lt;days&gt; | `days:Number` |
 | settings |  | 75 | Get the settings for the server | settings |  |
 | setup |  | 75 | Configures the bot in your guild | setup [part] |  |
 
@@ -72,8 +71,8 @@ title: Command List
 |    Command        |         Aliases        | Default Clearance |                        Description                        |      Usage      |    Arguments     |
 | :-------------:   | :--------------------: | :---------------: | :-------------------------------------------------------: | :-------------: | :--------------: |
 | channelinfo |  | 50 | Returns some useful info about a channel | channelinfo [channel] |  |
-| charinfo |  | 0 | Returns information about the characters provided | charinfo &lt;characters&gt; | `characters:string` |
-| inviteinfo | `inv` | 0 | Returns some useful info about a server from the invite link | inviteinfo &lt;invitecode&gt; | `invitecode:string` |
+| charinfo |  | 0 | Returns information about the characters provided | charinfo &lt;characters&gt; | `characters:String` |
+| inviteinfo | `inv` | 0 | Returns some useful info about a server from the invite link | inviteinfo &lt;invitecode&gt; | `invitecode:String` |
 | messageinfo |  | 50 | Returns some useful info about a message | messageinfo &lt;channel-message&gt; | `channel-message:Snowflake` |
 | roleinfo |  | 50 | Returns some useful info about a role | roleinfo &lt;role&gt; | `role:Role` |
 | server |  | 50 | Returns some useful information about the current server | server |  |
@@ -85,51 +84,51 @@ title: Command List
 |    Command        |         Aliases        | Default Clearance |                        Description                        |      Usage      |    Arguments     |
 | :-------------:   | :--------------------: | :---------------: | :-------------------------------------------------------: | :-------------: | :--------------: |
 | avatar |  | 0 | Gets a users avatar picture | avatar [user] | `user:User` |
-| id |  | 0 | Parse out the Discord id from any text | id &lt;text&gt; | `text:Text` |
-| jumbo |  | 0 | Sends a bigger version of the given emote(s) | jumbo &lt;emote&gt; | `emote:Emote` |
-| permissions | `perms` | 0 | Gets permission names from a permission integer | permissions &lt;permissions&gt; | `permissions:integer` |
+| id |  | 0 | Parse out the Discord id from any text | id &lt;text&gt; | `text:String` |
+| jumbo |  | 0 | Sends a bigger version of the given emote(s) | jumbo &lt;emote&gt; | `emote:Emoji` |
+| permissions | `perms` | 0 | Gets permission names from a permission integer | permissions &lt;permissions&gt; | `permissions:Number` |
 | remind remove | `yeet`, `delete` | 0 | Removes a reminder by its ID. | remind remove &lt;id&gt; | `id:number` |
 | remind list |  | 0 | Lists all of your reminders. | remind list |  |
-| remind set | `add` | 0 | Sets a reminder for the specified duration. | remind set &lt;duration&gt; &lt;reason&gt; | `duration:Duration`, `reason:String` |
-| snowflake |  | 0 | Gets information about a given snowflake | snowflake &lt;snowflake&gt; | `snowflake:integer` |
+| remind set | `add` | 0 | Sets a reminder for the specified duration. | remind set &lt;duration&gt; &lt;reason&gt; | `duration:Time`, `reason:String` |
+| snowflake |  | 0 | Gets information about a given snowflake | snowflake &lt;snowflake&gt; | `snowflake:Snowflake` |
 
 
 ### Moderation
 ---
 |    Command        |         Aliases        | Default Clearance |                        Description                        |      Usage      |    Arguments     |
 | :-------------:   | :--------------------: | :---------------: | :-------------------------------------------------------: | :-------------: | :--------------: |
-| archive channel |  | 50 | Archive commands | archive channel &lt;channel&gt; [amount] | `channel:Channel`, `amount:number` |
-| archive user |  | 50 | Archive commands | archive user &lt;user&gt; [amount] | `user:User`, `amount:number` |
+| archive channel |  | 50 | Archive commands | archive channel &lt;channel&gt; [amount] | `channel:ChannelText`, `amount:Number` |
+| archive user |  | 50 | Archive commands | archive user &lt;user&gt; [amount] | `user:User`, `amount:Number` |
 | ban | `terminate`, `yeet` | 50 | Bans or forcebans a user from the server | ban &lt;user&gt; [reason] | `user:User` |
-| cleanban |  | 50 | Bans a user and removes all their messages from the server | cleanban &lt;member&gt; [reason] | `member:Member` |
-| crossban | `poolban` | 75 | Crossban a user across multiple servers | crossban &lt;user&gt; &lt;reason&gt; | `user:User`, `reason:string` |
-| deafen |  | 50 | Deafens a member from a Voice Channel they're connected to | deafen &lt;user&gt; [reason] | `user:User` |
-| infraction search |  | 50 | Search for infractions of a user. | infraction search &lt;user&gt; [page] | `user:User`, `page:number` |
-| infraction info |  | 50 | Get information about an infraction. | infraction info &lt;id&gt; | `id:int32` |
-| infraction claim |  | 50 | Claims an infraction. | infraction claim &lt;infraction&gt; | `infraction:int32` |
-| infraction update |  | 50 | Updates the reason of an infraction. | infraction update &lt;infraction&gt; &lt;reason&gt; | `infraction:int32`, `reason:string` |
+| cleanban |  | 50 | Bans a user and removes all their messages from the server | cleanban &lt;member&gt; [reason] | `member:Member`, `reason:String` |
+| crossban | `poolban` | 75 | Crossban a user across multiple servers | crossban &lt;user&gt; &lt;reason&gt; | `user:User`, `reason:String` |
+| deafen |  | 50 | Deafens a member from a Voice Channel they're connected to | deafen &lt;user&gt; [reason] | `user:User`, `reason:String` |
+| infraction search |  | 50 | Search for infractions of a user. | infraction search &lt;user&gt; [page] | `user:User`, `page:Number` |
+| infraction info |  | 50 | Get information about an infraction. | infraction info &lt;id&gt; | `id:Number` |
+| infraction claim |  | 50 | Claims an infraction. | infraction claim &lt;infraction&gt; | `infraction:Number` |
+| infraction update |  | 50 | Updates the reason of an infraction. | infraction update &lt;infraction&gt; &lt;reason&gt; | `infraction:Number`, `reason:String` |
 | infraction modsearch | `msearch` | 50 | Search for moderation infractions of a user. | infraction modsearch &lt;user&gt; | `user:User` |
 | infraction offendersearch | `osearch` | 50 | Search for offender infractions of a user. | infraction offendersearch &lt;user&gt; | `user:User` |
-| infraction delete | `del`, `remove` | 50 | Delete an infraction. | infraction delete &lt;infraction&gt; | `infraction:int32` |
+| infraction delete | `del`, `remove` | 50 | Delete an infraction. | infraction delete &lt;infraction&gt; | `infraction:Number` |
 | kick |  | 50 | Kicks a user from the server | kick &lt;member&gt; [reason] | `member:Member` |
-| lockdown |  | 50 | Locks/unlocks a selected channel | lockdown &lt;channel&gt; &lt;true|false&gt; | `channel:Channel`, `lock:boolean` |
+| lockdown |  | 50 | Locks/unlocks a selected channel | lockdown &lt;channel&gt; &lt;true|false&gt; | `channel:ChannelText`, `lock:Boolean` |
 | multiban | `mban` | 50 | Bans or forcebans multiple people from a server | multiban &lt;user&gt; &lt;user2&gt;.... [reason] | `user:User` |
 | multikick | `mkick` | 50 | Kicks multiple people from a server | multikick &lt;member&gt; &lt;member2&gt;.... [reason] | `member:Member` |
 | multiunban | `munban` | 50 | Unbans multiple people from a server | multiunban &lt;user&gt; &lt;user2&gt;... [reason] | `user:User` |
 | multiwarn | `mwarn` | 50 | Warns multiple selected users | multiwarn &lt;member&gt; &lt;member2&gt;... [reason] | `user:User` |
-| mute | `tempmute` | 50 | Mutes the selected user | mute &lt;member&gt; &lt;duration&gt; [reason] | `member:Member`, `duration:Duration` |
+| mute | `tempmute` | 50 | Mutes the selected user | mute &lt;member&gt; &lt;duration&gt; [reason] | `member:Member`, `duration:Time` |
 | nickname | `nick` | 50 | Nicknames a user from the current server | nickname &lt;member&gt; [nickname] [reason] | `member:Member` |
 | prune |  | 50 | Prune users from the server | prune &lt;days&gt; [roles]... [reason] | `days:Number` |
-| purge all |  | 50 | Purges all messages in the current channel. | purge all &lt;number&gt; | `amount:int` |
-| purge embeds |  | 50 | Purges messages with embeds. | purge embeds &lt;number&gt; | `amount:int` |
-| purge images |  | 50 | Purges messages with attachments in the channel. | purge images &lt;number&gt; | `amount:int` |
-| purge bots |  | 50 | Purges bot messages from the current channel. | purge bots &lt;number&gt; | `amount:int` |
-| purge emojis |  | 50 | Purges messages with custom emojis. | purge emojis &lt;number&gt; | `amount:int` |
-| purge user |  | 50 | Purges a users messages from the current channel. | purge user &lt;member&gt; &lt;amount&gt; | `member:Member`, `amount:int` |
-| purge contains |  | 50 | Purges messages containing the query. | purge contains &lt;query&gt; &lt;amount&gt; | `query:string`, `amount:int` |
+| purge all |  | 50 | Purges all messages in the current channel. | purge all &lt;number&gt; | `amount:Number` |
+| purge embeds |  | 50 | Purges messages with embeds. | purge embeds &lt;number&gt; | `amount:Number` |
+| purge images |  | 50 | Purges messages with attachments in the channel. | purge images &lt;number&gt; | `amount:Number` |
+| purge bots |  | 50 | Purges bot messages from the current channel. | purge bots &lt;number&gt; | `amount:Number` |
+| purge emojis |  | 50 | Purges messages with custom emojis. | purge emojis &lt;number&gt; | `amount:Number` |
+| purge user |  | 50 | Purges a users messages from the current channel. | purge user &lt;member&gt; &lt;amount&gt; | `member:Member`, `amount:Number` |
+| purge contains |  | 50 | Purges messages containing the query. | purge contains &lt;query&gt; &lt;amount&gt; | `query:String`, `amount:Number` |
 | purge between |  | 50 | Purges messages between two messages. | purge between &lt;context1&gt; &lt;context2&gt; | `message1:Snowflake`, `message2:Snowflake` |
 | purge until |  | 50 | Purges messages until a message | purge until &lt;message&gt; | `message:Snowflake` |
-| slowmode |  | 50 | Sets a slowmode to the selected channel | slowmode &lt;duration&gt; [channel] | `duration:Duration` |
+| slowmode |  | 50 | Sets a slowmode to the selected channel | slowmode &lt;duration&gt; [channel] | `duration:Time` |
 | softban | `cleankick` | 50 | Bans and unbans a user from the server | softban &lt;member&gt; [reason] | `member:Member` |
 | tempban | `tempyeet` | 50 | Temporarily bans the selected user from the server | tempban &lt;member&gt; [reason] | `member:Member` |
 | unban | `pardon` | 50 | Unban a user from the server | unban &lt;user&gt; [reason] | `user:User` |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,8 +3,7 @@ id: commands
 title: Commands
 ---
 
-In this article, you'll learn everything you need to know about Bulbbot's commands, how to use arguments, etc. so you can become the ultimate Bulbbot
-command master!
+In this article, you'll learn everything you need to know about Bulbbot's commands, how to use arguments, etc. So you can become the ultimate Bulbbot command master!
 
 ### Command categories
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,9 +9,6 @@ A powerful Discord moderation bot with rich features allowing server Moderators 
 ### How to invite the bot
 You can read through our [getting started](getting-started) article that walks you through a quick and simple way to invite and set up Bulbbot in your server.
 
-### How to change Bulbbot's prefix
-You can change Bulbbot's prefix in your server using the `!configure prefix <prefix>` command.
-
 ### Is Bulbbot open source?
 Yes, Bulbbot is completely open source! You can find out GitHub repository [here](https://github.com/TeamBulbbot/bulbbot).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,35 +5,39 @@ title: Getting Started
 
 This guide will take you through a quick and simple way to add & set up Bulbbot in your server!
 
+:::caution note
+All the Bulbbot commands are available by typing `/`, it will show a list of commands and as you type the name of the command that you want to use, it will show a list of possible commands that matches with your input.
+:::
+
 ### 1. Adding the bot to your server
 
 You can find the invite link for Bulbbot [here](https://bulbbot.rocks/invite).
 
 ![Invite](./assets/Introduction/Invite.gif)
 
-### 2. Configuring Bulbbot's prefix
+### 2. Configuring the language
 
-By default, Bulbbot will listen to `!` as it's prefix. We recognize that a wide variety of other bots also use `!` as their prefix, which could interfere with using Bulbbot. You can change Bulbbot's prefix in your server using the `!configure prefix <prefix>` command.
+Since Bulbbot is a multi-language bot, you need to configure the language you want to use. You can do this by simply using the `/configure language <language>` command.
 
-:::tip
-You can ping Bulbbot and it'll respond with what its prefix is in your server!
-:::
+**Available languages:** `English, US (English US)`, `Slovak (Slovenčina)`, `Swedish (Svenska)`, `French (Français)`, `Portuguese (Português)`, `Czech (Čeština)`, `Italian (Italiano)` and `Hindi (हिंदी)`.
 
-![Prefix](./assets/Introduction/Change_Prefix.gif)
+![Language](./assets/Introduction/Language.gif)
+
+### 3. Configuring the timezone
+
+In front of all logging messages, Bulbbot will show the exactly time that the event happened, to make sure that the messages are in the right timezone, you need to configure the timezone of your server. You can do this by using the `/configure timezone <timezone>` command.
+
+**Available timezones (abbreviation):** `ANAT`, `AEDT`, `AEST`, `JST`, `AWST`, `WIB`, `BTT`, `UZT`, `GST`, `IST`, `MSK`, `CEST`, `BST`, `GMT`, `CVT`, `WGST`, `ART`, `EDT`, `CDT`, `CST`, `PDT`, `AKDT`, `HDT`, `HST`, `NUT`, `AoE` and `UTC`.
+
+![Timezone](./assets/Introduction/Timezone.gif)
 
 ### 3. Configuring logging
 
-Bulbbot comes with powerful logging features that allow you to log any actions in your server, from your Moderators taking actions on misbehavior, to role and channel updates, to even violations detected using Bulbbot's AutoMod. You can configure logging channels using the `!configure logging <type> <channel>` command.
+Bulbbot comes with powerful logging features that allow you to log any actions in your server, from your Moderators taking actions on misbehavior, to role and channel updates, to even violations detected using Bulbbot's AutoMod. You can configure logging channels using the `/configure logging <type> <channel>` command.
 
 **Available logging types:** `mod_logs`, `automod`, `banpool_logs`*, `message_logs`, `role_logs`, `member_logs`, `channel_logs`, `thread_logs`, `invite_logs`, `join_leave`, `other` and `all`
 
-![Logging](./assets/Introduction/Setup_Logging.gif)
-
-### 4. Configuring the muted role
-
-Dealing with spammers, trolls, and other problematic users joining your server can be a daunting task. At times, you or your Moderators might want to mute troublesome users to prevent them from causing more problems in your server. You can configure the muted role using the `!configure mute_role <role>` command.
-
-![Mute_role](./assets/Introduction/Setup_Mute-role.gif)
+![Logging](./assets/Introduction/Logging.gif)
 
 Aaand you're done! :tada: You've just set up Bulbbot's basic configuration in your server. There are of course many, many more configurable features Bulbbot offers like Clearance Levels, Command and Role overrides, AutoMod, and much more. The guides and documentation for all of our features can also be found on this site!
 

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -9,15 +9,14 @@ Bulbbot currently offers `11` logging types: `mod_logs`, `automod`, `banpool_log
 :::
 
 ### Mod Logs
-Once enabled, `mod_logs` logging will log all mod actions performed by the bot in the selected channel. You can enable mod action logging using the
-`!configuration logging mod_logs <channel>` command.
+Once enabled, `mod_logs` logging will log all mod actions performed by the bot in the selected channel. You can enable mod action logging using the `/configure logging type: Mod logs <channel>` command.
 
 
 ![ModLog](./assets/Configuration/Mod_Logs.png)
 
 ### Auto Mod
 Automod logging will log all automod violations detected by Bulbbot in the selected channel. Bulbbot will additionally log which actions 
-it took automatically, and the content it detected to trigger the automated action. You can configure automod logging using the `!configuration logging automod <channel>` command.
+it took automatically, and the content it detected to trigger the automated action. You can configure automod logging using the `/configure logging type: Automod logs <channel>` command.
 
 :::tip
 You can learn more about Bulbbot's automod [here](automod.md)
@@ -33,43 +32,43 @@ The banpool logs are available for the users who have a [premium](about-premium.
 - When another server joins the banpool.
 
 ### Message logs
-Message logging will log message upates/edits in the server. You can enable message logging using `!configuration logging message_logs <channel>` command.
-- Deleted messages (includes replies, stickers, embeds and attachements),
+Message logging will log message upates/edits in the server. You can enable message logging using `/configure logging type: Message logs <channel>` command.
+- Deleted messages (includes replies, stickers, embeds and attachments),
 - Edited messages.
 
 ![MessageLogs](./assets/Configuration/Message_Logs.png)
 
 ### Role logs 
-Role logs will log whenever an update happens to a role in the server. You can enable role logging using `!configuration logging role_logs <channel>` command (Bulbbot in the future will log role permission updates too).
+Role logs will log whenever an update happens to a role in the server. You can enable role logging using `/configure logging type: Role logs <channel>` command (Bulbbot in the future will log role permission updates too).
 
 ![RoleLogs](./assets/Configuration/Role_Logs.png)
 
 ### Member logs
-Member logs will log whenever a server member updates their server profile, i.e: nickname update. You can enable member logging using `!configuration logging member_logs <channel>` command. 
+Member logs will log whenever a server member updates their server profile, i.e: nickname update. You can enable member logging using `/configure logging type: Member logs <channel>` command. 
 
 ![MemberLogs](./assets/Configuration/Member_Logs.png)
 
 ### Channel logs 
-Channel logs will log whenever an update happens to a channel in the server. You can enable channel logging using `!configuration logging channel_logs <channel>` command (Bulbbot in the future will log channel permission updates).
+Channel logs will log whenever an update happens to a channel in the server. You can enable channel logging using `/configure logging type: Channel logs <channel>` command (Bulbbot in the future will log channel permission updates).
 
 ![ChannelLogs](./assets/Configuration/Channel_Logs.png)
 
 ### Thread Logs
-Thread logs will log whenever a thread is created or deleted in the server. You can enable thread logging using `!configuration logging thread_logs <channel>` command (Bulbbot in the future will log whenever a user leaves or joins a thread).
+Thread logs will log whenever a thread is created or deleted in the server. You can enable thread logging using `/configure logging type: Thread logs <channel>` command (Bulbbot in the future will log whenever a user leaves or joins a thread).
 ![ThreadLogs](./assets/Configuration/Thread_Logs.png)
 
 ### Invite Logs
-Invite logs will log whenever a invite is created or deleted in the server. You can enable invite logging using `!configuration logging invite_logs <channel>` command.
+Invite logs will log whenever a invite is created or deleted in the server. You can enable invite logging using `/configure logging type: Invite logs <channel>` command.
 
 ![InviteLogs](./assets/Configuration/Invite_Logs.png)
 
 ### Join/Leave logs
-Join/leave logs will log whenever a user leaves or joins the server. You can enable it by using `!configuration logging join_leave <channel>` command.
+Join/leave logs will log whenever a user leaves or joins the server. You can enable it by using `/configure logging type: Join/Leave logs <channel>` command.
 
 ![JoinLeaveLogs](./assets/Configuration/Join_Leave_Logs.png)
 
 ### Other Logs
-Other logs will log any other miscellaneous things listed below. You can enable it by using `!configuration logging other <channel>` command.
+Other logs will log any other miscellaneous things listed below. You can enable it by using `/configure logging type: Other <channel>` command.
 - Command Usage
 
 ![Otherlogs](./assets/Configuration/Other_Logs.png)

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -6,7 +6,7 @@ title: Slash Commands
 ###  What are slash commands? 
 In [December 2020](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ), Discord launched a new feature for bot developers to make it easier to interact with bots. You can bring this menu up with `/`. 
 
-Instead of spending hours trying to figure out the bots prefix or look thru the help menu, just press `/`, find Bulbbot and rock on.
+Instead of spending hours trying to figure out the bots prefix or look through the help menu, just press `/`, find Bulbbot and rock on.
 
 ### How to use slash commands?
 Like the name `/` slash. This will bring up the slash command menu, find the Bulbbot icon and press it. This will show all of the commands that Bulbbot offers.


### PR DESCRIPTION
### This PR:

- Rewrite the whole docs to use slash commands instead of normal commands.
- Changes the sections:
     - [x] Introduction
     - [x] Basics of Bulbbot
     - [x] Configuration
     - [ ] Moderating with Bulbot
     - [ ] Premium
     - [ ]  Community
- Update all the attachments that uses normal commands.
- Is related with https://github.com/TeamBulbbot/bulbbot/pull/336

> Note: This is just a initial commit, I didn't even changed the attachments in `getting-started.md` file. 😄 